### PR TITLE
Newtype

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,12 +19,13 @@ dependencies:
   - text
   - resource-pool
   - mtl
+  - mmorph
   - tasty
   - tasty-hedgehog
   - exceptions
   - unliftio
   - lifted-base
-  
+
 executables:
   hedgehog-db-testing:
     source-dirs:      src

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, TypeSynonymInstances, FlexibleInstances, NamedFieldPuns, LambdaCase, OverloadedStrings #-}
+{-# LANGUAGE ApplicativeDo, GeneralizedNewtypeDeriving, TypeSynonymInstances, FlexibleInstances, NamedFieldPuns, LambdaCase, OverloadedStrings #-}
 module Main where
 
 import Control.Monad.Morph (hoist)
@@ -175,12 +175,23 @@ createPost Post{postUserId, postTitle, postBody} = do
 randomUser :: (MonadGen m) => m NewUser
 randomUser = UserPoly <$> (pure ()) <*> (Gen.text (Range.constant 1 100) Gen.unicodeAll) <*> (Gen.text (Range.constant 1 100) Gen.unicodeAll)
 
+newtype CreatePost = CreatePost { unCreatePost :: User -> Post }
+
+instance Show CreatePost where
+  showsPrec p x =
+    showsPrec p (unCreatePost x (UserPoly 0 "" ""))
+
 -- | Function to generate a randomg UNSAVED post. However, please note, that
 -- this requires a SAVED User to be passed-in because `postUserId` is a
 -- required, non-nullable FK field.
-randomPost :: (MonadGen m) => User -> m Post
-randomPost UserPoly{userId} = Post <$> (pure userId) <*> (Gen.text (Range.constant 1 100) Gen.unicodeAll) <*> (Gen.text (Range.constant 1 100) Gen.unicodeAll)
-
+randomPost :: (MonadGen m) => m CreatePost
+randomPost = do
+  title <- Gen.text (Range.constant 1 100) Gen.unicodeAll
+  body <- Gen.text (Range.constant 1 100) Gen.unicodeAll
+  -- note you don't actually need the whole user here,
+  -- maybe having a UserId newtype would be better
+  pure . CreatePost $ \UserPoly{userId} ->
+    Post userId title body
 
 -- | This is the kind of test I am trying to write, but I have commented it out,
 -- because it is not compiling. The uncommented code below is just boilerplate
@@ -194,9 +205,12 @@ myProperty :: Pool Connection -> Property
 myProperty pool =
   property . hoist (withRollback pool) $ do
    newuser <- forAll randomUser
-   user <- lift $ createUser newuser
-   newpost <- forAll $ randomPost user
-   post <- lift $ createPost newpost
+   newpost <- forAll randomPost
+   -- evalM is a bit like a specialized 'try' or 'handle', will cause any
+   -- exception thrown in the thing it is evaluating to be to be located to the
+   -- 'evalM' line rather than just the property as a whole.
+   user <- evalM . lift $ createUser newuser
+   post <- evalM . lift $ createPost (unCreatePost newpost user)
    True === True
 --myProperty :: Pool Connection -> TestTree
 --myProperty pool = testProperty "My property" $ property $ pure ()


### PR DESCRIPTION
I took @nhibberd's PR https://github.com/saurabhnanda/hedgehog-db-testing/pull/1 and added the newtype/show instance for creating a post.

I also added some `evalM` lines which locates the exception location a lot more precisely when there is an error.

For example:
```
  My property: FAIL (0.02s)
      ✗ My property failed after 1 test and 22 shrinks.

            ┏━━ src/Main.hs ━━━
        204 ┃ myProperty :: Pool Connection -> Property
        205 ┃ myProperty pool =
        206 ┃   property . hoist (withRollback pool) $ do
        207 ┃    newuser <- forAll randomUser
            ┃    │ UserPoly { userId = () , userName = "\NUL" , userEmail = "\NUL" }
        208 ┃    newpost <- forAll randomPost
            ┃    │ Post { postUserId = 0 , postTitle = "\NUL" , postBody = "\NUL" }
        209 ┃    user <- evalM . lift $ createUser newuser
        210 ┃    post <- evalM . lift $ createPost (unCreatePost newpost user)
            ┃    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            ┃    │ ━━━ Exception: FormatError ━━━
            ┃    │ FormatError {fmtMessage = "2 '?' characters, but 3 parameters", fmtQuery = "insert in
to posts(title, body) values(?, ?) returning id, user_id, post, title", fmtParams = ["24","\NUL","\NUL"]
}
        211 ┃    True === True
```

You get better shrinking with `Applicative` so I added `ApplicativeDo` to your language pragmas, so I could use `do` notation in `randomPost`. It would have been a bit harder/noiser doing the whole return a function thing with regular applicative syntax i think. Can be done though if you don't like `ApplicativeDo`.